### PR TITLE
Fix syntax error in real world dataset

### DIFF
--- a/prismatic/vla/datasets/real_world_dataset.py
+++ b/prismatic/vla/datasets/real_world_dataset.py
@@ -36,7 +36,7 @@ class HDF5Dataset(torch.utils.data.Dataset):
                 min_window_size = 16,
                 max_window_size = 16,
                 image_transform = None,
-                other_config=()) -> None:,
+                other_config=()) -> None:
         
         super(HDF5Dataset).__init__()
         self.episode_ids = episode_ids


### PR DESCRIPTION
## Summary
- fix stray colon in dataset constructor

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .` *(fails: found 483 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685260f3f194832ca114a4f092b09a8a