### PR TITLE
Fix pretrained model download path

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ torchrun --standalone --nnodes 1 --nproc-per-node 8 main.py fit \
 > [!NOTE]
 > For pretraining UniVLA only on BridgeV2 or Human (Ego4D) data, please modify ```vla.type``` to ```prism-dinosiglip-224px+mx-bridge(human)``` correspondingly. Detailed setups can be found in ```./prismatic/conf/vla.py```.
 
+The `--pretrain_vlm` argument can be either a local directory containing
+`config.json` and the checkpoint to load or a model name returned by
+`prismatic.available_model_names()`. When a model name (e.g.
+`prism-dinosiglip-224px+7b`) is specified, the weights will be automatically
+downloaded from the Hugging Face Hub.
+
 ```bash
 ### Experiment on a 32-GPU cluster
 GPUS_PER_NODE=8  

--- a/prismatic/models/load.py
+++ b/prismatic/models/load.py
@@ -61,8 +61,23 @@ def load(
 
         # Get paths for `config.json` and pretrained checkpoint
         config_json, checkpoint_pt = run_dir / "config.json", run_dir / "checkpoints" / "latest-checkpoint.pt"
-        assert config_json.exists(), f"Missing `config.json` for `{run_dir = }`"
-        assert checkpoint_pt.exists(), f"Missing checkpoint for `{run_dir = }`"
+
+        if not (config_json.exists() and checkpoint_pt.exists()):
+            # Directory exists but missing expected files -> fall back to HF Hub if possible
+            if model_id_or_path not in GLOBAL_REGISTRY:
+                raise AssertionError(f"Missing `config.json` for `{run_dir = }`")
+
+            overwatch.info(f"Local path `{run_dir}` missing files; falling back to HF Hub entry `{model_id_or_path}`")
+            with overwatch.local_zero_first():
+                model_id = GLOBAL_REGISTRY[model_id_or_path]["model_id"]
+                config_json = hf_hub_download(
+                    repo_id=HF_HUB_REPO, filename=f"{model_id}/config.json", cache_dir=cache_dir
+                )
+                checkpoint_pt = hf_hub_download(
+                    repo_id=HF_HUB_REPO,
+                    filename=f"{model_id}/checkpoints/latest-checkpoint.pt",
+                    cache_dir=cache_dir,
+                )
     else:
         if model_id_or_path not in GLOBAL_REGISTRY:
             raise ValueError(f"Couldn't find `{model_id_or_path = }; check `prismatic.available_model_names()`")

--- a/vla-scripts/train.py
+++ b/vla-scripts/train.py
@@ -35,7 +35,7 @@ class TrainConfig:
     vla: VLAConfig = field(
         default_factory=VLAConfig.get_choice_class(VLARegistry.DINOSIGLIP_224PX_MX_BRIDGE.vla_id)
     )
-    pretrain_vlm: str = '/path/to/your/prism-dinosiglip-224px_7b'
+    pretrain_vlm: str = 'prism-dinosiglip-224px+7b'
     lam_path: str = "latent_action_model/logs/task_centric_lam_stage2/epoch=0-step=200000.ckpt"
 
     # LAM setting
@@ -68,7 +68,7 @@ class TrainConfig:
     seed: int = 42                                                  # Random seed (for reproducibility)
 
     # HF Hub Credentials (for any gated models)
-    hf_token: Union[str, Path] = ''                
+    hf_token: Union[str, Path] = ''
 
     # Tracking Parameters
     trackers: Tuple[str, ...] = ("jsonl", "wandb")                  # Trackers to initialize (if W&B, add config!)
@@ -118,7 +118,7 @@ def train(cfg: TrainConfig) -> None:
     if cfg.image_aug:
         cfg.run_id += "--image_aug"
 
-    cfg.run_id += '-Latent-Action-Pretraining'
+    cfg.run_id += "-Latent-Action-Pretraining"
     # Start =>> Build Directories and Set Randomness
     overwatch.info('"Do or do not; there is no try."', ctx_level=1)
     # hf_token = cfg.hf_token.read_text().strip() if isinstance(cfg.hf_token, Path) else os.environ[cfg.hf_token]
@@ -182,7 +182,7 @@ def train(cfg: TrainConfig) -> None:
     overwatch.info(
         f"# Parameters (in millions): {num_params / 10**6:.3f} Total, {num_trainable_params / 10**6:.3f} Trainable"
     )
-    
+
     from latent_action_model.genie.modules.lam import ControllableDINOLatentActionModel
 
     latent_action_model = ControllableDINOLatentActionModel(
@@ -194,10 +194,10 @@ def train(cfg: TrainConfig) -> None:
         enc_blocks=cfg.lam_enc_blocks,
         dec_blocks=cfg.lam_dec_blocks,
         num_heads=cfg.lam_num_heads,
-        dropout=0.,
+        dropout=0.0,
     )
 
-    lam_ckpt = torch.load(cfg.lam_path)['state_dict']
+    lam_ckpt = torch.load(cfg.lam_path)["state_dict"]
     new_ckpt = {}
     for key in lam_ckpt.keys():
         new_ckpt[key.replace("lam.", "")] = lam_ckpt[key]
@@ -222,8 +222,8 @@ def train(cfg: TrainConfig) -> None:
         aug_transform=aug_transform,
     )
 
-    special_tokens_dict = {'additional_special_tokens': [f'<ACT_{i}>' for i in range(cfg.codebook_size)]}
-    num_added_toks = action_tokenizer.add_special_tokens(special_tokens_dict)
+    special_tokens_dict = {"additional_special_tokens": [f"<ACT_{i}>" for i in range(cfg.codebook_size)]}
+    action_tokenizer.add_special_tokens(special_tokens_dict)
 
     # Save dataset statistics for de-normalization at inference time
     if overwatch.is_rank_zero():


### PR DESCRIPTION
## Summary
- use `prism-dinosiglip-224px+7b` as default model
- clarify in README how `--pretrain_vlm` works
- allow `load()` to fall back to HF if local folder is incomplete
- remove unused variable and trailing whitespace

## Testing
- `ruff format prismatic/models/load.py vla-scripts/train.py`
- `ruff check prismatic/models/load.py vla-scripts/train.py`
- `pip install pre-commit` *(failed: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852b11a7ed0832ca899dcf4193616f8