### PR TITLE
Add TacoPlay dataset configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ torchrun --standalone --nnodes 1 --nproc-per-node 8 main.py fit \
 `prismatic.available_model_names()`.
 
 > [!NOTE]
-> For pretraining UniVLA only on BridgeV2 or Human (Ego4D) data, please modify ```vla.type``` to ```prism-dinosiglip-224px+mx-bridge(human)``` correspondingly. Detailed setups can be found in ```./prismatic/conf/vla.py```.
+> For pretraining UniVLA only on BridgeV2 or Human (Ego4D) data, please modify ```vla.type``` to ```prism-dinosiglip-224px+mx-bridge(human)``` correspondingly. Detailed setups can be found in ```./prismatic/conf/vla.py`. To train solely on the TacoPlay dataset use ```vla.type prism-dinosiglip-224px+mx-taco-play```.
 
 The RLDS TFRecord directory passed to `--data_root_dir` should contain the
 `bridge_oxe` dataset in the standard TFDS layout:
@@ -240,6 +240,27 @@ torchrun --nproc_per_node 8 vla-scripts/train.py \
     --pretrain_vlm prism-dinosiglip-224px+7b \
     --lam_path latent_action_model/logs/task_centric_lam_stage2/epoch=0-step=200000.ckpt \
     --run_root_dir runs
+```
+
+The RLDS directory for TacoPlay should follow a similar layout:
+```
+/path/to/taco_play_rlds/
+    taco_play/
+        1.0.0/
+            dataset_info.json
+            taco_play.tfrecord-00000-of-00005
+            taco_play.tfrecord-00001-of-00005
+            ...
+```
+You can launch training on TacoPlay with:
+```bash
+torchrun --nproc_per_node 8 vla-scripts/train.py \
+    --vla.type prism-dinosiglip-224px+mx-taco-play \
+    --data_root_dir /path/to/taco_play_rlds \
+    --pretrain_vlm prism-dinosiglip-224px+7b \
+    --lam_path latent_action_model/logs/task_centric_lam_stage2/epoch=0-step=200000.ckpt \
+    --run_root_dir runs
+```
 
 ```bash
 ### Experiment on a 32-GPU cluster

--- a/prismatic/conf/vla.py
+++ b/prismatic/conf/vla.py
@@ -104,6 +104,14 @@ class Exp_DinoSigLIP_224px_Bridge(Exp_SigLIP_224px_Bridge):
 
 
 @dataclass
+class Exp_DinoSigLIP_224px_TacoPlay(Exp_SigLIP_224px_Bridge):
+    vla_id: str = "prism-dinosiglip-224px+mx-taco-play"
+    base_vlm: Union[str, Path] = "prism-dinosiglip-224px+7b"
+
+    data_mix: str = "taco_play"
+
+
+@dataclass
 class Exp_DinoSigLIP_224px_Human(Exp_SigLIP_224px_Bridge):
     vla_id: str = "prism-dinosiglip-224px+mx-human"
     base_vlm: Union[str, Path] = "prism-dinosiglip-224px+7b"
@@ -138,6 +146,9 @@ class VLARegistry(Enum):
 
     # Pre-training on Human data only
     DINOSIGLIP_224PX_MX_HUMAN = Exp_DinoSigLIP_224px_Human
+
+    # Pre-training on TacoPlay data only
+    DINOSIGLIP_224PX_MX_TACO_PLAY = Exp_DinoSigLIP_224px_TacoPlay
 
     # Pre-training on full dataset
     DINOSIGLIP_224PX_MX_OXE_MAGIC_SOUP_PLUS = Exp_DinoSigLIP_224px_OXE_Magic_Soup_Plus

--- a/prismatic/vla/datasets/rlds/oxe/mixtures.py
+++ b/prismatic/vla/datasets/rlds/oxe/mixtures.py
@@ -18,6 +18,10 @@ OXE_NAMED_MIXTURES: Dict[str, List[Tuple[str, float]]] = {
     "droid": [
         ("droid", 1.0),
     ],
+
+    "taco_play": [
+        ("taco_play", 1.0),
+    ],
     
     # === Human-data Only ===
     "Ego4D": [ 


### PR DESCRIPTION
## Summary
- support training on the TacoPlay dataset
- register a TacoPlay-only mix
- document TacoPlay dataset layout and usage

## Testing
- `pytest -q`
- `ruff check .` *(fails: found numerous style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68546e07a7bc832c94a30bbaac6acf92