### PR TITLE
Fix crop_and_resize clipping

### DIFF
--- a/experiments/robot/openvla_utils.py
+++ b/experiments/robot/openvla_utils.py
@@ -100,6 +100,7 @@ def crop_and_resize(image, crop_scale, batch_size):
 
     # Center-crop and then resize back up
     crop_frac = tf.sqrt(crop_scale)
+    crop_frac = tf.clip_by_value(crop_frac, 0, 1)
     image = tf.image.central_crop(image, crop_frac)
     image = tf.image.resize(image, (224, 224), method="bilinear")
 


### PR DESCRIPTION
## Summary
- ensure crop fraction is clipped to `[0, 1]` in `crop_and_resize`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857262c66cc832ca4635bf97e68da98