### PR TITLE
Set foreach=False in AdamW optimizers

### DIFF
--- a/prismatic/training/strategies/ddp.py
+++ b/prismatic/training/strategies/ddp.py
@@ -92,7 +92,8 @@ class DDPStrategy(TrainingStrategy):
             num_warmup_steps = int(num_training_steps * self.warmup_ratio)
 
             assert self.weight_decay == 0, "DDP training does not currently support `weight_decay` > 0!"
-            self.optimizer = AdamW(trainable_params, lr=self.learning_rate, weight_decay=self.weight_decay)
+            # Disable foreach ops to reduce peak memory usage
+            self.optimizer = AdamW(trainable_params, lr=self.learning_rate, weight_decay=self.weight_decay, foreach=False)
             self.lr_scheduler = get_cosine_schedule_with_warmup(self.optimizer, num_warmup_steps, num_training_steps)
             for param_group in self.optimizer.param_groups:
                 param_group["lr"] = 0.0
@@ -101,7 +102,8 @@ class DDPStrategy(TrainingStrategy):
             num_warmup_steps = 0
 
             assert self.weight_decay == 0, "DDP training does not currently support `weight_decay` > 0!"
-            self.optimizer = AdamW(trainable_params, lr=self.learning_rate, weight_decay=self.weight_decay)
+            # Disable foreach ops to reduce peak memory usage
+            self.optimizer = AdamW(trainable_params, lr=self.learning_rate, weight_decay=self.weight_decay, foreach=False)
             self.lr_scheduler = get_constant_schedule(self.optimizer)
 
         else:

--- a/prismatic/training/strategies/fsdp.py
+++ b/prismatic/training/strategies/fsdp.py
@@ -214,7 +214,8 @@ class FSDPStrategy(TrainingStrategy):
             groups = [{"params": decay, "weight_decay": self.weight_decay}, {"params": no_decay, "weight_decay": 0.0}]
 
             # Create Optimizer & LR Scheduler
-            self.optimizer = AdamW(groups, lr=self.learning_rate)
+            # Disable foreach ops to reduce peak memory usage
+            self.optimizer = AdamW(groups, lr=self.learning_rate, foreach=False)
             self.lr_scheduler = get_cosine_schedule_with_warmup(self.optimizer, num_warmup_steps, num_training_steps)
             for param_group in self.optimizer.param_groups:
                 param_group["lr"] = 0.0
@@ -239,7 +240,8 @@ class FSDPStrategy(TrainingStrategy):
             groups = [{"params": decay, "weight_decay": self.weight_decay}, {"params": no_decay, "weight_decay": 0.0}]
 
             # Create Optimizer & LR Scheduler
-            self.optimizer = AdamW(groups, lr=self.learning_rate)
+            # Disable foreach ops to reduce peak memory usage
+            self.optimizer = AdamW(groups, lr=self.learning_rate, foreach=False)
             self.lr_scheduler = get_constant_schedule(self.optimizer)
 
         else:


### PR DESCRIPTION
## Summary
- reduce memory usage of FSDP and DDP optimizer instantiations

## Testing
- `pytest -q`
- `python - <<'EOF'
try:
    import torch
    from torch.optim import AdamW
    from torch.nn import Linear
    model = Linear(1,1)
    opt = AdamW(model.parameters(), foreach=False)
    print('optimizer created')
except Exception as e:
    print('error:', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6857f8596d00832cb7eb345655f8e82a