### PR TITLE
Fix InfoNCE token projection indexing

### DIFF
--- a/prismatic/training/strategies/base_strategy.py
+++ b/prismatic/training/strategies/base_strategy.py
@@ -307,9 +307,11 @@ class TrainingStrategy(ABC):
                     # === InfoNCE Loss ===
                     hidden = output.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
-                    mask_tokens = batch["labels"][:, 1:] != IGNORE_INDEX
-                    z = self.vlm.token_projector(hidden)[mask_tokens]
-                    z_aug = self.vlm.token_projector(hidden_aug)[mask_tokens]
+                    mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
+                    proj_hidden = self.vlm.token_projector(hidden)
+                    proj_hidden_aug = self.vlm.token_projector(hidden_aug)
+                    z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
+                    z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
                     z = torch.nn.functional.normalize(z, dim=1)
                     z_aug = torch.nn.functional.normalize(z_aug, dim=1)
                     logits = z @ z_aug.t() / 0.1
@@ -487,9 +489,11 @@ class TrainingStrategy(ABC):
                     # === InfoNCE Loss ===
                     hidden = output.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
-                    mask_tokens = batch["labels"][:, 1:] != IGNORE_INDEX
-                    z = self.vlm.token_projector(hidden)[mask_tokens]
-                    z_aug = self.vlm.token_projector(hidden_aug)[mask_tokens]
+                    mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
+                    proj_hidden = self.vlm.token_projector(hidden)
+                    proj_hidden_aug = self.vlm.token_projector(hidden_aug)
+                    z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
+                    z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
                     z = torch.nn.functional.normalize(z, dim=1)
                     z_aug = torch.nn.functional.normalize(z_aug, dim=1)
                     logits = z @ z_aug.t() / 0.1


### PR DESCRIPTION
## Summary
- reshape token features before InfoNCE projection
- ensure mask indexing is flattened in both training loops

## Testing
- `ruff check prismatic/training/strategies/base_strategy.py`
- `black --check prismatic/training/strategies/base_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_6857ff309e20832cbe21c9444b2da05c