### PR TITLE
Fix InfoNCE projection runtime error

### DIFF
--- a/prismatic/training/strategies/base_strategy.py
+++ b/prismatic/training/strategies/base_strategy.py
@@ -307,9 +307,13 @@ class TrainingStrategy(ABC):
                     # === InfoNCE Loss ===
                     hidden = output.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
-                    mask_tokens = batch["labels"][:, 1:] != IGNORE_INDEX
-                    z = self.vlm.token_projector(hidden)[mask_tokens]
-                    z_aug = self.vlm.token_projector(hidden_aug)[mask_tokens]
+                    mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
+                    proj_hidden = self.vlm.token_projector(hidden)
+                    proj_hidden_aug = self.vlm.token_projector(hidden_aug)
+                    z = proj_hidden.view(-1, proj_hidden.size(-1))[mask_tokens]
+                    z_aug = proj_hidden_aug.view(-1, proj_hidden_aug.size(-1))[mask_tokens]
+                    z = z.view(-1, proj_hidden.size(-1))
+                    z_aug = z_aug.view(-1, proj_hidden_aug.size(-1))
                     z = torch.nn.functional.normalize(z, dim=1)
                     z_aug = torch.nn.functional.normalize(z_aug, dim=1)
                     logits = z @ z_aug.t() / 0.1
@@ -487,9 +491,13 @@ class TrainingStrategy(ABC):
                     # === InfoNCE Loss ===
                     hidden = output.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
-                    mask_tokens = batch["labels"][:, 1:] != IGNORE_INDEX
-                    z = self.vlm.token_projector(hidden)[mask_tokens]
-                    z_aug = self.vlm.token_projector(hidden_aug)[mask_tokens]
+                    mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
+                    proj_hidden = self.vlm.token_projector(hidden)
+                    proj_hidden_aug = self.vlm.token_projector(hidden_aug)
+                    z = proj_hidden.view(-1, proj_hidden.size(-1))[mask_tokens]
+                    z_aug = proj_hidden_aug.view(-1, proj_hidden_aug.size(-1))[mask_tokens]
+                    z = z.view(-1, proj_hidden.size(-1))
+                    z_aug = z_aug.view(-1, proj_hidden_aug.size(-1))
                     z = torch.nn.functional.normalize(z, dim=1)
                     z_aug = torch.nn.functional.normalize(z_aug, dim=1)
                     logits = z @ z_aug.t() / 0.1


### PR DESCRIPTION
## Summary
- reshape token projector inputs without collapsing to 1D
- maintain 2-D masked selections when computing InfoNCE

## Testing
- `ruff check prismatic/training/strategies/base_strategy.py`
- `black --check prismatic/training/strategies/base_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_6857ff309e20832cbe21c9444b2da05c