### PR TITLE
Fix InfoNCE feature flattening

### DIFF
--- a/prismatic/training/strategies/base_strategy.py
+++ b/prismatic/training/strategies/base_strategy.py
@@ -308,11 +308,20 @@ class TrainingStrategy(ABC):
                     hidden = output.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
-                    proj_hidden = self.vlm.token_projector(hidden.view(-1, hidden.size(-1)))
-                    proj_hidden_aug = self.vlm.token_projector(hidden_aug.view(-1, hidden_aug.size(-1)))
+
+                    flat_hidden = hidden.view(-1, hidden.size(-1))
+                    if flat_hidden.dim() == 1:
+                        flat_hidden = flat_hidden.unsqueeze(0)
+                    proj_hidden = self.vlm.token_projector(flat_hidden)
+
+                    flat_hidden_aug = hidden_aug.view(-1, hidden_aug.size(-1))
+                    if flat_hidden_aug.dim() == 1:
+                        flat_hidden_aug = flat_hidden_aug.unsqueeze(0)
+                    proj_hidden_aug = self.vlm.token_projector(flat_hidden_aug)
+
                     z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
                     z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
-                   
+
                     z = torch.nn.functional.normalize(z, dim=1)
                     z_aug = torch.nn.functional.normalize(z_aug, dim=1)
                     logits = z @ z_aug.t() / 0.1
@@ -490,8 +499,17 @@ class TrainingStrategy(ABC):
                     hidden = output.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
-                    proj_hidden = self.vlm.token_projector(hidden.view(-1, hidden.size(-1)))
-                    proj_hidden_aug = self.vlm.token_projector(hidden_aug.view(-1, hidden_aug.size(-1)))
+
+                    flat_hidden = hidden.view(-1, hidden.size(-1))
+                    if flat_hidden.dim() == 1:
+                        flat_hidden = flat_hidden.unsqueeze(0)
+                    proj_hidden = self.vlm.token_projector(flat_hidden)
+
+                    flat_hidden_aug = hidden_aug.view(-1, hidden_aug.size(-1))
+                    if flat_hidden_aug.dim() == 1:
+                        flat_hidden_aug = flat_hidden_aug.unsqueeze(0)
+                    proj_hidden_aug = self.vlm.token_projector(flat_hidden_aug)
+
                     z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
                     z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
                     z = torch.nn.functional.normalize(z, dim=1)


### PR DESCRIPTION
## Summary
- ensure hidden states flattened to 2D before projection
- apply the same flattening logic for augmented features
- use flattened tensors when indexing for InfoNCE

## Testing
- `ruff check prismatic/training/strategies/base_strategy.py`
- `ruff check .` *(fails: many existing issues outside modified files)*

------
https://chatgpt.com/codex/tasks/task_e_68581b4a07d0832c88d287cc5c52c1d5