### PR TITLE
Refactor InfoNCE masking

### DIFF
--- a/prismatic/training/strategies/base_strategy.py
+++ b/prismatic/training/strategies/base_strategy.py
@@ -309,18 +309,17 @@ class TrainingStrategy(ABC):
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
 
-                    flat_hidden = hidden.view(-1, hidden.size(-1))
-                    if flat_hidden.dim() == 1:
-                        flat_hidden = flat_hidden.unsqueeze(0)
-                    proj_hidden = self.vlm.token_projector(flat_hidden)
+                    flat_hidden = hidden.reshape(-1, hidden.shape[-1])
+                    flat_hidden_aug = hidden_aug.reshape(-1, hidden_aug.shape[-1])
 
-                    flat_hidden_aug = hidden_aug.view(-1, hidden_aug.size(-1))
-                    if flat_hidden_aug.dim() == 1:
-                        flat_hidden_aug = flat_hidden_aug.unsqueeze(0)
-                    proj_hidden_aug = self.vlm.token_projector(flat_hidden_aug)
+                    masked_hidden = flat_hidden[mask_tokens]
+                    masked_hidden_aug = flat_hidden_aug[mask_tokens]
 
-                    z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
-                    z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
+                    proj_hidden = self.vlm.token_projector(masked_hidden)
+                    proj_hidden_aug = self.vlm.token_projector(masked_hidden_aug)
+
+                    z = proj_hidden.reshape(-1, proj_hidden.shape[-1])
+                    z_aug = proj_hidden_aug.reshape(-1, proj_hidden_aug.shape[-1])
 
                     z = torch.nn.functional.normalize(z, dim=1)
                     z_aug = torch.nn.functional.normalize(z_aug, dim=1)
@@ -500,18 +499,17 @@ class TrainingStrategy(ABC):
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
 
-                    flat_hidden = hidden.view(-1, hidden.size(-1))
-                    if flat_hidden.dim() == 1:
-                        flat_hidden = flat_hidden.unsqueeze(0)
-                    proj_hidden = self.vlm.token_projector(flat_hidden)
+                    flat_hidden = hidden.reshape(-1, hidden.shape[-1])
+                    flat_hidden_aug = hidden_aug.reshape(-1, hidden_aug.shape[-1])
 
-                    flat_hidden_aug = hidden_aug.view(-1, hidden_aug.size(-1))
-                    if flat_hidden_aug.dim() == 1:
-                        flat_hidden_aug = flat_hidden_aug.unsqueeze(0)
-                    proj_hidden_aug = self.vlm.token_projector(flat_hidden_aug)
+                    masked_hidden = flat_hidden[mask_tokens]
+                    masked_hidden_aug = flat_hidden_aug[mask_tokens]
 
-                    z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
-                    z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
+                    proj_hidden = self.vlm.token_projector(masked_hidden)
+                    proj_hidden_aug = self.vlm.token_projector(masked_hidden_aug)
+
+                    z = proj_hidden.reshape(-1, proj_hidden.shape[-1])
+                    z_aug = proj_hidden_aug.reshape(-1, proj_hidden_aug.shape[-1])
                     z = torch.nn.functional.normalize(z, dim=1)
                     z_aug = torch.nn.functional.normalize(z_aug, dim=1)
                     logits = z @ z_aug.t() / 0.1


### PR DESCRIPTION
## Summary
- simplify InfoNCE blocks in `base_strategy.py`
- use reshape instead of view and remove unnecessary dimension checks
- compute masked tokens before projecting

## Testing
- `ruff check prismatic/training/strategies/base_strategy.py`


------
https://chatgpt.com/codex/tasks/task_e_68581e1effd0832c905adc368d643e60