### PR TITLE
Refactor InfoNCE masking

### DIFF
--- a/prismatic/training/strategies/base_strategy.py
+++ b/prismatic/training/strategies/base_strategy.py
@@ -309,21 +309,17 @@ class TrainingStrategy(ABC):
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
 
-                    flat_hidden = hidden.view(-1, hidden.size(-1))
-                    if flat_hidden.dim() == 1:
-                        flat_hidden = flat_hidden.unsqueeze(0)
-                    proj_hidden = self.vlm.token_projector(flat_hidden)
+                    flat_hidden = hidden.reshape(-1, hidden.shape[-1])
+                    flat_hidden_aug = hidden_aug.reshape(-1, hidden_aug.shape[-1])
 
-                    flat_hidden_aug = hidden_aug.view(-1, hidden_aug.size(-1))
-                    if flat_hidden_aug.dim() == 1:
-                        flat_hidden_aug = flat_hidden_aug.unsqueeze(0)
-                    proj_hidden_aug = self.vlm.token_projector(flat_hidden_aug)
+                    masked_hidden = flat_hidden[mask_tokens]
+                    masked_hidden_aug = flat_hidden_aug[mask_tokens]
 
-                    z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
-                    z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
+                    proj_hidden = self.vlm.token_projector(masked_hidden)
+                    proj_hidden_aug = self.vlm.token_projector(masked_hidden_aug)
 
-                    z = torch.nn.functional.normalize(z, dim=1)
-                    z_aug = torch.nn.functional.normalize(z_aug, dim=1)
+                    z = torch.nn.functional.normalize(proj_hidden, dim=1)
+                    z_aug = torch.nn.functional.normalize(proj_hidden_aug, dim=1)
                     logits = z @ z_aug.t() / 0.1
                     targets = torch.arange(z.size(0), device=z.device)
                     info_nce = (
@@ -500,20 +496,18 @@ class TrainingStrategy(ABC):
                     hidden_aug = output_aug.hidden_states[-1][:, self.vlm.vision_backbone.num_patches : -1, :]
                     mask_tokens = (batch["labels"][:, 1:] != IGNORE_INDEX).view(-1)
 
-                    flat_hidden = hidden.view(-1, hidden.size(-1))
-                    if flat_hidden.dim() == 1:
-                        flat_hidden = flat_hidden.unsqueeze(0)
-                    proj_hidden = self.vlm.token_projector(flat_hidden)
+                    flat_hidden = hidden.reshape(-1, hidden.shape[-1])
+                    flat_hidden_aug = hidden_aug.reshape(-1, hidden_aug.shape[-1])
 
-                    flat_hidden_aug = hidden_aug.view(-1, hidden_aug.size(-1))
-                    if flat_hidden_aug.dim() == 1:
-                        flat_hidden_aug = flat_hidden_aug.unsqueeze(0)
-                    proj_hidden_aug = self.vlm.token_projector(flat_hidden_aug)
+                    masked_hidden = flat_hidden[mask_tokens]
+                    masked_hidden_aug = flat_hidden_aug[mask_tokens]
 
-                    z = proj_hidden[mask_tokens].view(-1, proj_hidden.size(-1))
-                    z_aug = proj_hidden_aug[mask_tokens].view(-1, proj_hidden_aug.size(-1))
-                    z = torch.nn.functional.normalize(z, dim=1)
-                    z_aug = torch.nn.functional.normalize(z_aug, dim=1)
+                    proj_hidden = self.vlm.token_projector(masked_hidden)
+                    proj_hidden_aug = self.vlm.token_projector(masked_hidden_aug)
+
+                    z = torch.nn.functional.normalize(proj_hidden, dim=1)
+                    z_aug = torch.nn.functional.normalize(proj_hidden_aug, dim=1)
+
                     logits = z @ z_aug.t() / 0.1
                     targets = torch.arange(z.size(0), device=z.device)
                     info_nce = (


### PR DESCRIPTION
## Summary
- simplify projection steps in base strategy
- compute InfoNCE embeddings using reshape and masking

## Testing
- `ruff check prismatic/training/strategies/base_strategy.py`

------
https://chatgpt.com/codex/tasks/task_e_685824626ae0832cabb2a47a93bdb6d1