### PR TITLE
Add DDP strategy support and test

### DIFF
--- a/prismatic/training/materialize.py
+++ b/prismatic/training/materialize.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional
 import torch
 
 from prismatic.models.vlms import PrismaticVLM
-from prismatic.training.strategies import FSDPStrategy, TrainingStrategy
+from prismatic.training.strategies import DDPStrategy, FSDPStrategy, TrainingStrategy
 
 # Registry =>> Maps ID --> {cls(), kwargs} :: supports FSDP for now, but DDP handler is also implemented!
 TRAIN_STRATEGIES = {
@@ -18,6 +18,7 @@ TRAIN_STRATEGIES = {
     "fsdp-full-shard": {"cls": FSDPStrategy, "kwargs": {"sharding_strategy": "full-shard"}},
     "no-shard": {"cls": FSDPStrategy, "kwargs": {"sharding_strategy": "no-shard"}},
     "fsdp-no-shard": {"cls": FSDPStrategy, "kwargs": {"sharding_strategy": "no-shard"}},
+    "ddp": {"cls": DDPStrategy, "kwargs": {}},
 }
 
 

--- a/prismatic/training/strategies/ddp.py
+++ b/prismatic/training/strategies/ddp.py
@@ -66,7 +66,13 @@ class DDPStrategy(TrainingStrategy):
             # Additional Reference (to better understand gradient checkpointing in PyTorch writ large)
             #   => github.com/prigoyal/pytorch_memonger/blob/master/tutorial/Checkpointing_for_PyTorch_models.ipynb
             overwatch.info("Enabling Gradient Checkpointing on LLM Backbone", ctx_level=1)
-            self.vlm.llm_backbone.gradient_checkpointing_enable()
+            if hasattr(self.vlm.llm_backbone, "gradient_checkpointing_enable"):
+                self.vlm.llm_backbone.gradient_checkpointing_enable()
+            else:
+                overwatch.warning(
+                    "LLM backbone does not support gradient checkpointing; proceeding without it",
+                    ctx_level=1,
+                )
 
         # Move to Device =>> Note parameters are in full precision (*mixed precision* will only autocast as appropriate)
         overwatch.info("Placing Entire VLM (Vision Backbone, LLM Backbone, Projector Weights) on GPU", ctx_level=1)

--- a/tests/strategies/test_materialize.py
+++ b/tests/strategies/test_materialize.py
@@ -7,6 +7,7 @@ from torch.distributed.fsdp import ShardingStrategy
 
 from prismatic.training.materialize import get_train_strategy
 from prismatic.training.strategies.fsdp import FSDPStrategy
+from prismatic.training.strategies.ddp import DDPStrategy
 
 
 class TinyBackbone(nn.Module):
@@ -44,3 +45,24 @@ def test_get_train_strategy_no_shard():
     )
     assert isinstance(strategy, FSDPStrategy)
     assert strategy.fsdp_sharding_strategy == ShardingStrategy.NO_SHARD
+
+
+def test_get_train_strategy_ddp():
+    strategy = get_train_strategy(
+        "ddp",
+        vlm=TinyVLM(),
+        device_id=0,
+        stage="full-finetune",
+        epochs=1,
+        max_steps=None,
+        global_batch_size=1,
+        per_device_batch_size=1,
+        learning_rate=1e-3,
+        weight_decay=0.0,
+        max_grad_norm=1.0,
+        lr_scheduler_type="constant",
+        warmup_ratio=0.0,
+        enable_gradient_checkpointing=False,
+        enable_mixed_precision_training=False,
+    )
+    assert isinstance(strategy, DDPStrategy)


### PR DESCRIPTION
## Summary
- support `ddp` option in training strategy factory
- test that `ddp` returns a `DDPStrategy`
- handle VLMs missing `gradient_checkpointing_enable`

## Testing
- `pytest -q` *(fails: 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68587852b298832cb440ee2725e07dd3