### PR TITLE
Add Qwen2.5 backbone

### DIFF
--- a/prismatic/conf/models.py
+++ b/prismatic/conf/models.py
@@ -290,6 +290,12 @@ class Ext_Exp_3B_Phi_2(Exp_7B_One_Stage):
     llm_backbone_id: str = "phi-2-3b"
 
 
+@dataclass
+class Ext_Exp_0p5B_Qwen2(Exp_7B_One_Stage):
+    model_id: str = "qwen2.5+0.5b"
+    llm_backbone_id: str = "qwen2.5-0.5b"
+
+
 # Section 4.3B :: ✌️ --> Co-training on Language-only Data
 #   =>> Note :: Run with `--dataset.type "llava-multimodal" (multimodal data only / no co-training)
 @dataclass
@@ -538,6 +544,7 @@ class ModelRegistry(Enum):
     EXT_EXP_MISTRAL_V1_7B = Ext_Exp_7B_Mistral_V1
     EXT_EXP_MISTRAL_INSTRUCT_V1_7B = Ext_Exp_7B_Mistral_Instruct_V1
     EXT_EXP_PHI_2_3B = Ext_Exp_3B_Phi_2
+    EXT_EXP_QWEN2_0P5B = Ext_Exp_0p5B_Qwen2
 
     # Cotraining w/ Unimodal Data
     EXP_VICUNA_NO_COTRAINING_7B = Exp_7B_Vicuna_No_Cotraining

--- a/prismatic/extern/hf/configuration_prismatic.py
+++ b/prismatic/extern/hf/configuration_prismatic.py
@@ -54,6 +54,7 @@ LLM_BACKBONE_TO_HF_PATH = {
     "mistral-v0.1-7b-instruct": "mistralai/Mistral-7B-Instruct-v0.1",
 
     "phi-2-3b": "microsoft/phi-2",
+    "qwen2.5-0.5b": "Qwen/Qwen2.5-0.5B",
 }
 LLM_BACKBONE_TO_HF_METACLASS = {
     "llama2-7b-pure": "llama", "llama2-13b-pure": "llama", "llama2-7b-chat": "llama", "llama2-13b-chat": "llama",
@@ -62,6 +63,7 @@ LLM_BACKBONE_TO_HF_METACLASS = {
     "mistral-v0.1-7b-pure": "mistral", "mistral-v0.1-7b-instruct": "mistral",
 
     "phi-2-3b": "phi",
+    "qwen2.5-0.5b": "qwen2",
 }
 
 VALID_VISION_BACKBONES = set(VISION_BACKBONE_TO_RESOLUTION.keys())

--- a/prismatic/models/backbones/llm/__init__.py
+++ b/prismatic/models/backbones/llm/__init__.py
@@ -2,3 +2,4 @@ from .base_llm import LLMBackbone
 from .llama2 import LLaMa2LLMBackbone
 from .mistral import MistralLLMBackbone
 from .phi import PhiLLMBackbone
+from .qwen import Qwen2LLMBackbone

--- a/prismatic/models/backbones/llm/qwen.py
+++ b/prismatic/models/backbones/llm/qwen.py
@@ -1,0 +1,63 @@
+"""qwen.py
+
+Class definition for Qwen2 models.
+"""
+
+from typing import Optional, Sequence, Type
+
+import torch
+from torch import nn as nn
+from transformers import Qwen2ForCausalLM
+from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
+
+from prismatic.models.backbones.llm.base_llm import HFCausalLLMBackbone
+from prismatic.models.backbones.llm.prompting import PromptBuilder, PurePromptBuilder
+
+# Registry => support Qwen2.5-0.5B model
+QWEN2_MODELS = {
+    "qwen2.5-0.5b": {
+        "llm_family": "qwen2",
+        "llm_cls": Qwen2ForCausalLM,
+        "hf_hub_path": "Qwen/Qwen2.5-0.5B",
+    }
+}
+
+
+class Qwen2LLMBackbone(HFCausalLLMBackbone):
+    def __init__(
+        self,
+        llm_backbone_id: str,
+        llm_max_length: int = 2048,
+        hf_token: Optional[str] = None,
+        inference_mode: bool = False,
+        use_flash_attention_2: bool = True,
+    ) -> None:
+        super().__init__(
+            llm_backbone_id,
+            llm_max_length=llm_max_length,
+            hf_token=hf_token,
+            inference_mode=inference_mode,
+            use_flash_attention_2=use_flash_attention_2,
+            **QWEN2_MODELS[llm_backbone_id],
+        )
+
+        # Add PAD token handling similar to other models
+        self.tokenizer.add_special_tokens({"pad_token": "<|extra_0|>"})
+        self.llm.config.pad_token_id = self.tokenizer.pad_token_id
+        self.llm.resize_token_embeddings(len(self.tokenizer), pad_to_multiple_of=64)
+
+    @property
+    def prompt_builder_fn(self) -> Type[PromptBuilder]:
+        return PurePromptBuilder
+
+    @property
+    def transformer_layer_cls(self) -> Type[nn.Module]:
+        return Qwen2DecoderLayer
+
+    @property
+    def half_precision_dtype(self) -> torch.dtype:
+        return torch.bfloat16
+
+    @property
+    def last_layer_finetune_modules(self) -> Sequence[nn.Module]:
+        return (self.llm.model.embed_tokens, self.llm.model.layers[-1], self.llm.lm_head)

--- a/prismatic/models/materialize.py
+++ b/prismatic/models/materialize.py
@@ -9,7 +9,13 @@ from typing import Optional, Tuple
 
 from transformers import PreTrainedTokenizerBase
 
-from prismatic.models.backbones.llm import LLaMa2LLMBackbone, LLMBackbone, MistralLLMBackbone, PhiLLMBackbone
+from prismatic.models.backbones.llm import (
+    LLaMa2LLMBackbone,
+    LLMBackbone,
+    MistralLLMBackbone,
+    PhiLLMBackbone,
+    Qwen2LLMBackbone,
+)
 from prismatic.models.backbones.vision import (
     CLIPViTBackbone,
     DinoCLIPViTBackbone,
@@ -70,6 +76,9 @@ LLM_BACKBONES = {
 
     # === Phi-2 Backbone ===
     "phi-2-3b": {"cls": PhiLLMBackbone, "kwargs": {}},
+
+    # === Qwen2.5 Backbone ===
+    "qwen2.5-0.5b": {"cls": Qwen2LLMBackbone, "kwargs": {}},
 }
 
 # fmt: on

--- a/prismatic/models/registry.py
+++ b/prismatic/models/registry.py
@@ -683,6 +683,19 @@ MODEL_REGISTRY = {
             "train_epochs": 1,
         }
     },
+    "qwen2.5+0.5b": {
+        "model_id": "qwen2.5+0.5b",
+        "names": ["Qwen2.5 0.5B"],
+        "description": {
+            "name": "Qwen2.5 0.5B",
+            "optimization_procedure": "single-stage",
+            "visual_representation": "CLIP ViT-L/14 @ 336px",
+            "image_processing": "Letterbox",
+            "language_model": "Qwen2.5 0.5B",
+            "datasets": ["LLaVa v1.5 Instruct"],
+            "train_epochs": 1,
+        }
+    },
 }
 
 # Build Global Registry (Model ID, Name) -> Metadata

--- a/prismatic/tools/check_q_proj.py
+++ b/prismatic/tools/check_q_proj.py
@@ -1,0 +1,21 @@
+import argparse
+from pathlib import Path
+
+from prismatic.models import load
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Print q_proj shapes from a checkpoint")
+    parser.add_argument("model", type=str, help="Model directory or model name")
+    args = parser.parse_args()
+
+    vlm = load(Path(args.model))
+    layer = vlm.llm_backbone.llm.model.layers[0].self_attn
+    w_shape = tuple(layer.q_proj.weight.shape)
+    b_shape = tuple(layer.q_proj.bias.shape) if layer.q_proj.bias is not None else None
+    print("q_proj weight:", w_shape)
+    print("q_proj bias:", b_shape)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `Qwen2LLMBackbone` and registry entry for Qwen2.5-0.5B
- register new model config and enumeration
- map Qwen2.5-0.5B in HuggingFace config
- import new backbone in materialization utils and `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c59706884832cbdd9d7066b740056