### PR TITLE
Support YAML configs when loading pretrained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ torchrun --standalone --nnodes 1 --nproc-per-node 8 main.py fit \
 - To initiate pre-training, please refer to the following scipt or simply run ```bash ./vla-scripts/train.sh```:
 
     --hf_token <your_hf_token>  # required for gated models like LLaMA-2
-`--pretrain_vlm` may refer to a local directory containing `config.json` and
-`checkpoints/latest-checkpoint.pt` or to a registered model name from
+`--pretrain_vlm` may refer to a local directory containing `config.json` (or
+`config.yaml`) and `checkpoints/latest-checkpoint.pt` or to a registered model name from
 `prismatic.available_model_names()`.
 
 > [!NOTE]


### PR DESCRIPTION
## Summary
- allow `prismatic.models.load.load()` to read `config.yaml` as well as `config.json`
- gracefully handle missing PyYAML dependency
- document new behavior in README
- adjust tests and add coverage for YAML configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c82f07ee0832cbb19e8193b110b6d