### PR TITLE
Fix merge leftovers in model loader

### DIFF
--- a/prismatic/models/load.py
+++ b/prismatic/models/load.py
@@ -125,13 +125,7 @@ def load(
         if "model" not in cfg_data:
             if "vla" in cfg_data and "base_vlm" in cfg_data["vla"]:
                 try:
-<<<<<<< ntcgs5-codex/fix-missing--model--section-in-config-file
-                    model_cfg = asdict(
-                        ModelConfig.get_choice_class(cfg_data["vla"]["base_vlm"])()
-                    )
-=======
-                    model_cfg = ModelConfig.get_choice_class(cfg_data["vla"]["base_vlm"])().__dict__
->>>>>>> main
+                    model_cfg = asdict(ModelConfig.get_choice_class(cfg_data["vla"]["base_vlm"] )())
                 except Exception as e:
                     raise KeyError(
                         f"'model' section missing from config file {config_file} "


### PR DESCRIPTION
## Summary
- clean up unresolved merge markers in `prismatic/models/load.py`
- ensure fallback model config is built via `asdict`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ce7b10d84832ca2a78ffb3ea36719