### PR TITLE
Fix missing resize strategy key

### DIFF
--- a/prismatic/models/load.py
+++ b/prismatic/models/load.py
@@ -141,6 +141,13 @@ def load(
         else:
             model_cfg = cfg_data["model"]
 
+        # Fill in missing defaults for older config files
+        if "image_resize_strategy" not in model_cfg:
+            overwatch.warning(
+                "'image_resize_strategy' missing from config; defaulting to 'letterbox'"
+            )
+            model_cfg["image_resize_strategy"] = "letterbox"
+
     # = Load Individual Components necessary for Instantiating a VLM =
     #   =>> Print Minimal Config
     overwatch.info(


### PR DESCRIPTION
## Summary
- avoid KeyError when `image_resize_strategy` is missing in older model configs
- warn and default to `letterbox`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf81a0640832ca360a68b7be8b7ca