### PR TITLE
Add flagship projects gallery layout with animated expansion

### DIFF
--- a/assets/synergy_placeholder.svg
+++ b/assets/synergy_placeholder.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" role="img" aria-labelledby="title desc">
+  <title id="title">Synergy placeholder artwork</title>
+  <desc id="desc">Abstract gradient artwork used as a placeholder for the Synergy project image.</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e90ff"/>
+      <stop offset="50%" stop-color="#7a5cdb"/>
+      <stop offset="100%" stop-color="#f468b7"/>
+    </linearGradient>
+    <linearGradient id="overlay" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.6)"/>
+      <stop offset="50%" stop-color="rgba(255,255,255,0.2)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0)"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="900" fill="url(#gradient)" rx="56" ry="56"/>
+  <rect width="1200" height="900" fill="url(#overlay)" opacity="0.45" rx="56" ry="56"/>
+  <g fill="#ffffff" font-family="'Poppins', 'Segoe UI', sans-serif" text-anchor="middle">
+    <text x="50%" y="52%" font-size="96" font-weight="700" letter-spacing="4">SYNERGY</text>
+    <text x="50%" y="63%" font-size="42" font-weight="300" letter-spacing="4">Team Showcases</text>
+  </g>
+</svg>

--- a/docs/flagship-projects/index.html
+++ b/docs/flagship-projects/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Flagship Projects – Autonomous UAS</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__header">
+        <p class="page__eyebrow">Systems Lead · Aerial Robotics</p>
+        <h1 class="page__title">Flagship Projects</h1>
+      </header>
+      <section class="project" aria-labelledby="project-title">
+        <div class="project__media" data-gallery>
+          <figure class="project__frame project__frame--primary">
+            <img src="../../assets/teaser_univla.png" alt="Autonomous UAS quadcopter simulation collage" loading="lazy" />
+          </figure>
+          <figure class="project__frame project__frame--secondary" aria-hidden="true">
+            <img src="../../assets/real-world-exp_1.png" alt="Competition team celebrating podium finish" loading="lazy" />
+          </figure>
+          <figure class="project__frame project__frame--secondary" aria-hidden="true">
+            <img src="../../assets/synergy_placeholder.svg" alt="Synergy showcase team photo" loading="lazy" />
+          </figure>
+        </div>
+        <article class="project__details">
+          <div class="project__meta">
+            <p class="project__scope">Aerial Robotics · Systems Lead</p>
+            <h2 id="project-title" class="project__title">Autonomous UAS</h2>
+          </div>
+          <p class="project__summary">
+            Led the systems team delivering a competition-ready quadcopter with full autonomy stack, perception, and safety interlocks.
+          </p>
+          <dl class="project__tags">
+            <div class="project__tags-row">
+              <dt>Stage</dt>
+              <dd>SAE AeroTHON · 2024</dd>
+            </div>
+            <div class="project__tags-row">
+              <dt>Stack</dt>
+              <dd>ROS 2 · PX4 Autopilot · OpenCV · Raspberry Pi</dd>
+            </div>
+          </dl>
+          <button class="project__toggle" type="button" data-toggle aria-expanded="false">
+            <span class="project__toggle-label" data-toggle-label>Expand gallery</span>
+            <span class="project__toggle-icon" aria-hidden="true"></span>
+          </button>
+          <footer class="project__cta">
+            <a class="project__cta-button" href="#flight-log">Read the flight log</a>
+          </footer>
+        </article>
+      </section>
+    </main>
+    <script src="./media-gallery.js"></script>
+  </body>
+</html>

--- a/docs/flagship-projects/media-gallery.js
+++ b/docs/flagship-projects/media-gallery.js
@@ -1,0 +1,31 @@
+(function () {
+  const gallery = document.querySelector('[data-gallery]');
+  const toggle = document.querySelector('[data-toggle]');
+  const label = document.querySelector('[data-toggle-label]');
+
+  if (!gallery || !toggle || !label) {
+    return;
+  }
+
+  const expandedText = 'Collapse gallery';
+  const collapsedText = 'Expand gallery';
+
+  const updateState = (isExpanded) => {
+    toggle.setAttribute('aria-expanded', String(isExpanded));
+    label.textContent = isExpanded ? expandedText : collapsedText;
+    gallery.classList.toggle('is-expanded', isExpanded);
+
+    // Sync aria-hidden for secondary frames so screen readers announce them only when visible.
+    gallery
+      .querySelectorAll('.project__frame--secondary')
+      .forEach((frame) => frame.setAttribute('aria-hidden', String(!isExpanded)));
+  };
+
+  // Ensure initial state keeps the primary image centered vertically.
+  updateState(false);
+
+  toggle.addEventListener('click', () => {
+    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+    updateState(!isExpanded);
+  });
+})();

--- a/docs/flagship-projects/styles.css
+++ b/docs/flagship-projects/styles.css
@@ -1,0 +1,346 @@
+:root {
+  color-scheme: light;
+  font-family: "Poppins", "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --bg: #f4f6ff;
+  --bg-card: #ffffff;
+  --bg-glass: rgba(255, 255, 255, 0.86);
+  --text-primary: #0f1b42;
+  --text-secondary: #4d5b88;
+  --accent: #6657ff;
+  --accent-soft: rgba(102, 87, 255, 0.12);
+  --shadow-soft: 0 24px 80px rgba(15, 27, 66, 0.12);
+  --shadow-soft-lg: 0 40px 120px rgba(15, 27, 66, 0.18);
+  --border-soft: rgba(108, 126, 196, 0.25);
+  --transition-normal: 280ms cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(102, 87, 255, 0.18), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(15, 27, 66, 0.12), transparent 45%), var(--bg);
+  display: flex;
+  justify-content: center;
+  padding: clamp(32px, 6vw, 72px) clamp(20px, 5vw, 64px);
+  color: var(--text-primary);
+}
+
+.page {
+  width: min(1200px, 100%);
+  background: var(--bg-card);
+  border-radius: 36px;
+  box-shadow: var(--shadow-soft-lg);
+  padding: clamp(28px, 4vw, 56px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 5vw, 48px);
+}
+
+.page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.page__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.page__title {
+  margin: 0;
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.08;
+}
+
+.project {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: clamp(32px, 5vw, 60px);
+  align-items: stretch;
+  min-height: clamp(520px, 80vh, 720px);
+}
+
+.project__media {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  height: min(640px, 70vh);
+  background: var(--accent-soft);
+  border-radius: 30px;
+  padding: clamp(18px, 3vw, 30px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  transition: height var(--transition-normal), box-shadow var(--transition-normal), gap var(--transition-normal);
+  overflow: hidden;
+}
+
+.project__frame {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  background: #0d1535;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.project__frame img {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: contain;
+  transition: transform var(--transition-normal), filter var(--transition-normal);
+}
+
+.project__frame--primary {
+  min-height: min(420px, 55vh);
+  background: linear-gradient(140deg, rgba(102, 87, 255, 0.22), rgba(15, 27, 66, 0.6));
+}
+
+.project__frame--secondary {
+  opacity: 0;
+  transform: translateY(48px) scale(0.96);
+  pointer-events: none;
+  height: 0;
+}
+
+.project__details {
+  background: var(--bg-glass);
+  border-radius: 28px;
+  padding: clamp(24px, 4vw, 36px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+  box-shadow: var(--shadow-soft);
+}
+
+.project__scope {
+  margin: 0;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.project__title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.7rem);
+  line-height: 1.1;
+}
+
+.project__summary {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.project__tags {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.project__tags-row {
+  display: flex;
+  gap: 12px;
+  font-size: 0.95rem;
+  align-items: baseline;
+}
+
+.project__tags-row dt {
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 56px;
+}
+
+.project__tags-row dd {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.project__toggle {
+  border: none;
+  border-radius: 16px;
+  padding: 14px 18px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  background: linear-gradient(135deg, rgba(102, 87, 255, 0.16), rgba(102, 87, 255, 0.42));
+  color: var(--accent);
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 220ms ease;
+}
+
+.project__toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(102, 87, 255, 0.25);
+}
+
+.project__toggle:focus-visible {
+  outline: 2px solid rgba(102, 87, 255, 0.8);
+  outline-offset: 4px;
+}
+
+.project__toggle-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 2px solid currentColor;
+  position: relative;
+}
+
+.project__toggle-icon::before,
+.project__toggle-icon::after {
+  content: "";
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 60%;
+  height: 2px;
+  background: currentColor;
+  transform: translate(-50%, -50%);
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.project__toggle-icon::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.project__cta {
+  margin-top: auto;
+}
+
+.project__cta-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 22px;
+  border-radius: 999px;
+  background: var(--text-primary);
+  color: white;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 20px 30px rgba(15, 27, 66, 0.24);
+  transition: transform 200ms ease, box-shadow 220ms ease;
+}
+
+.project__cta-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 28px 45px rgba(15, 27, 66, 0.32);
+}
+
+.project__cta-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+/* Expanded state */
+.project__media.is-expanded {
+  height: 100vh;
+  justify-content: stretch;
+  gap: clamp(16px, 3vw, 28px);
+  padding: clamp(16px, 2.5vw, 24px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5), 0 30px 60px rgba(15, 27, 66, 0.2);
+}
+
+.project__media.is-expanded .project__frame {
+  flex: 1;
+  min-height: 0;
+}
+
+.project__media.is-expanded .project__frame img {
+  height: 100%;
+  object-fit: cover;
+}
+
+.project__media.is-expanded .project__frame--primary {
+  min-height: unset;
+}
+
+.project__media.is-expanded .project__frame--secondary {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+  height: auto;
+  animation: gallery-reveal 520ms ease forwards;
+}
+
+.project__media.is-expanded .project__frame--secondary:nth-of-type(2) {
+  animation-delay: 120ms;
+}
+
+.project__media.is-expanded .project__frame--secondary:nth-of-type(3) {
+  animation-delay: 240ms;
+}
+
+.project__media.is-expanded + .project__details .project__toggle-icon::after {
+  opacity: 0;
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+.project__media.is-expanded + .project__details .project__toggle-label::after {
+  content: "";
+}
+
+@keyframes gallery-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(48px) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 1080px) {
+  body {
+    padding: clamp(24px, 6vw, 48px);
+  }
+
+  .project {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .project__media {
+    order: 2;
+    height: 60vh;
+  }
+
+  .project__media.is-expanded {
+    height: min(120vh, 1000px);
+  }
+}
+
+@media (max-width: 720px) {
+  .page {
+    padding: clamp(20px, 6vw, 32px);
+    border-radius: 28px;
+  }
+
+  .project {
+    gap: clamp(20px, 6vw, 32px);
+  }
+
+  .project__details {
+    padding: clamp(20px, 6vw, 28px);
+  }
+
+  .project__frame--primary {
+    min-height: 280px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a flagship projects gallery demo page under `docs/flagship-projects`
- center the primary image on initial load and expand to a full-height stack with animated reveals
- include an accessible placeholder asset for the third gallery image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb05cb0c48832cb8d1c4aaf9180b16